### PR TITLE
fix: exit with success boolean

### DIFF
--- a/dbt_py/main.py
+++ b/dbt_py/main.py
@@ -64,4 +64,5 @@ def main() -> None:
     - https://docs.getdbt.com/reference/programmatic-invocations
     """
     dbt.context.base.get_context_modules = new_get_context_modules
-    dbt.cli.main.dbtRunner().invoke(sys.argv[1:])
+    result = dbt.cli.main.dbtRunner().invoke(sys.argv[1:])
+    return not result.success


### PR DESCRIPTION
This makes the exit code 1 when an error occurred in the underlying DBT invocation, and zero otherwise. It's particularly necessary for CI, where the current code will not surface errors

## Summary by Sourcery

Fix the exit code behavior to return a non-zero code on DBT invocation errors, improving error detection in CI environments.

Bug Fixes:
- Ensure the program exits with a non-zero code when an error occurs during the DBT invocation, allowing CI to correctly detect failures.