### PR TITLE
Respect the dbt exit codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The existing Python modules are available in the dbt Jinja context under the `mo
 While in preview, this package is only available from GitHub:
 
 ```
-pip install git+https://github.com/Bilbottom/dbt-py@v0.0.2
+pip install git+https://github.com/Bilbottom/dbt-py@v0.0.3
 ```
 
 This will be made available on PyPI once it's ready for general use.
@@ -130,3 +130,14 @@ This is still in preview, and there are a few things to be added before it's rea
 - Support for importing any number of packages (currently only one package is supported)
 - Configuration via config files and CLI arguments (currently only environment variables are supported)
 - More robust testing
+
+## Contributing 🤝
+
+Raise an issue, or fork the repo and open a pull request.
+
+This project uses [Poetry](https://python-poetry.org/) for dependency management and [pre-commit](https://pre-commit.com/) for linting. After cloning the repo, install the dependencies and enable pre-commit:
+
+```
+poetry install --sync --with dev,test
+pre-commit install --install-hooks
+```

--- a/coverage.svg
+++ b/coverage.svg
@@ -9,13 +9,13 @@
     </mask>
     <g mask="url(#a)">
         <path fill="#555" d="M0 0h63v20H0z"/>
-        <path fill="#97CA00" d="M63 0h36v20H63z"/>
+        <path fill="#4c1" d="M63 0h36v20H63z"/>
         <path fill="url(#b)" d="M0 0h99v20H0z"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">94%</text>
-        <text x="80" y="14">94%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">95%</text>
+        <text x="80" y="14">95%</text>
     </g>
 </svg>

--- a/dbt_py/main.py
+++ b/dbt_py/main.py
@@ -63,4 +63,10 @@ def main() -> None:
     - https://docs.getdbt.com/reference/programmatic-invocations
     """
     dbt.context.base.get_context_modules = new_get_context_modules
-    dbt.cli.main.dbtRunner().invoke(sys.argv[1:])
+    result = dbt.cli.main.dbtRunner().invoke(sys.argv[1:])
+    if result.success:
+        sys.exit(0)
+    elif result.exception is None:
+        sys.exit(1)
+    else:
+        sys.exit(2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "dbt-py-wrap"  # Not `dbt-py` to avoid confusion with the DbtPy package (PyPI requirement)
-version = "0.0.2"
+version = "0.0.3"
 description = "Python wrapper for dbt-core to extend dbt with custom Python."
 readme = "README.md"
 authors = ["Bilbottom"]

--- a/tests/integration/test__integration.py
+++ b/tests/integration/test__integration.py
@@ -2,11 +2,13 @@
 Integration tests for the package.
 """
 
+import dataclasses
 import pathlib
 import shutil
 import textwrap
 import unittest.mock
 
+import dbt.cli.main
 import pytest
 
 import dbt_py
@@ -33,7 +35,7 @@ EXAMPLE_COMPILED = textwrap.dedent(
 
 
 @pytest.fixture
-def mock_env(monkeypatch) -> None:
+def mock_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     Mock the environment variables used by dbt_py.
     """
@@ -50,7 +52,7 @@ def mock_env(monkeypatch) -> None:
 @pytest.fixture
 def teardown() -> None:
     """
-    Remove the compiled directory if it exists.
+    Remove the dbt target directory if it exists.
     """
     yield
     # TODO: I think this should be dynamic
@@ -64,6 +66,46 @@ def test__dbt_can_be_successfully_invoked(mock_env, teardown) -> None:
     Test that dbt can be successfully invoked.
     """
     with unittest.mock.patch("sys.argv", ["", "compile", *ARGS]):
-        dbt_py.main()
+        with pytest.raises(SystemExit) as exit_info:
+            dbt_py.main()
 
+    assert exit_info.value.code == 0
     assert EXAMPLE_FILE.read_text(encoding="utf-8").strip() == EXAMPLE_COMPILED.strip()
+
+
+@pytest.mark.parametrize(
+    "success, exception, expected_exit_code",
+    [
+        (True, None, 0),
+        (False, None, 1),
+        (False, Exception("something bad"), 2),
+    ],
+)
+def test__errors_return_the_correct_exit_code(
+    monkeypatch: pytest.MonkeyPatch,
+    success: bool,
+    exception: BaseException | None,
+    expected_exit_code: int,
+) -> None:
+    """
+    Test that the correct exit code is returned, following the dbt docs:
+
+    - https://docs.getdbt.com/reference/programmatic-invocations#dbtrunnerresult
+    """
+
+    @dataclasses.dataclass
+    class MockRunnerResult:
+        success: bool
+        exception: BaseException | None
+
+    class MockRunner:
+        def invoke(self, args):  # noqa
+            return MockRunnerResult(success=success, exception=exception)
+
+    monkeypatch.setattr(dbt.cli.main, "dbtRunner", MockRunner)
+
+    with unittest.mock.patch("sys.argv", ["", "compile", *ARGS]):
+        with pytest.raises(SystemExit) as exit_info:
+            dbt_py.main()
+
+    assert exit_info.value.code == expected_exit_code


### PR DESCRIPTION
> [!NOTE]
>
> This is an adjusted version of #34, originally raised by @alexmaras.

dbt commands will return exit codes `0`, `1`, or `2` depending on the run result, but these were being masked by this shim (see #36).

This PR updates the shim to respect the dbt exit codes following the dbt docs:

- https://docs.getdbt.com/reference/programmatic-invocations#dbtrunnerresult